### PR TITLE
[EC66] deprecation of EC66 rule for Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deleted
 
+- [#4](https://github.com/green-code-initiative/ecoCode-python/issues/4) Deprecate rule EC66 for Python because not applicable (see details inside issue)
+
 ## [1.4.0] - 2023-08-08
 
 ### Added

--- a/src/main/java/fr/greencodeinitiative/python/checks/AvoidDoubleQuoteCheck.java
+++ b/src/main/java/fr/greencodeinitiative/python/checks/AvoidDoubleQuoteCheck.java
@@ -23,6 +23,11 @@ import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.StringLiteral;
 import org.sonar.plugins.python.api.tree.Tree;
 
+/**
+ * @deprecated not applicable for Python
+ * (check discussion inside issue https://github.com/green-code-initiative/ecoCode-python/issues/4)
+ */
+@Deprecated(forRemoval = true)
 @Rule(key = "EC66")
 public class AvoidDoubleQuoteCheck extends PythonSubscriptionCheck {
     public static final String MESSAGE_RULE = "Avoid using quotation mark (\"), prefer using simple quote (')";

--- a/src/test/java/fr/greencodeinitiative/python/checks/AvoidDoubleQuoteTest.java
+++ b/src/test/java/fr/greencodeinitiative/python/checks/AvoidDoubleQuoteTest.java
@@ -20,6 +20,7 @@ package fr.greencodeinitiative.python.checks;
 import org.junit.Test;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
+@Deprecated
 public class AvoidDoubleQuoteTest {
     @Test
     public void test() {


### PR DESCRIPTION
deprecation of EC66 for Python becasue finally not applicable for Python.

check discussion on issue https://github.com/green-code-initiative/ecoCode-python/issues/4

other related PR in `ecocode` repository : https://github.com/green-code-initiative/ecoCode/pull/261